### PR TITLE
[breaking] when NODE_ENV is `production`, export mocks instead of real validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Custom React PropType validators that we use at Airbnb. Use of [airbnb-js-shims]
  - `uniqueArrayOf`: `uniqueArray`, with a type validator applied. Like `PropTypes.arrayOf`, but with uniqueness.
  - `withShape`: takes a PropType and a shape, and allows a shape to be enforced on any non-null/undefined value.
 
+## Production
+Since `PropTypes` are typically not included in production builds of React, this library’s functionality serves no useful purpose. As such, when the `NODE_ENV` environment variable is `"production"`, instead of exporting the implementations of all these prop types, we export mock functions - in other words, something that ensures that no exceptions are thrown, but does no validation. When environment variables are inlined (via a browserify transform or webpack plugin), then tools like webpack or uglify are able to determine that only the mocks will be imported - and can avoid including the entire implementations in the final bundle that is sent to the browser. This allows for a much smaller ultimate file size, and faster in-browser performance, without sacrificing the benefits of `PropTypes` themselves.
+
 ## Tests
 Simply clone the repo, `npm install`, and run `npm test`
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./build');
+module.exports = process.env.NODE_ENV === 'production' ? require('./build/mocks') : require('./build');


### PR DESCRIPTION
It'd be ideal to test locally and ensure this is working as intended.