### PR TITLE
add keysOf prop type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Custom React PropType validators that we use at Airbnb. Use of [airbnb-js-shims]
  - `explicitNull`: only allow `null` or `undefined`/omission - and only `null` when required.
  - `forbidExtraProps`: pass your entire `propTypes` object into this function, and any nonspecified prop will error.
  - `integer`: require the prop be an integer.
+ - `keysOf`: pass in a proptype, and require all the keys of a prop to have that type
  - `mutuallyExclusiveProps`: provide a propType, and a list of props, and only one prop out of the list will be permitted, validated by the given propType.
  - `mutuallyExclusiveTrueProps`: provide a list of props, and all must be booleans, and only one is allowed to be true.
  - `nChildren`: require a specific amount of children.

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import componentWithName from './componentWithName';
 import explicitNull from './explicitNull';
 import forbidExtraProps from './forbidExtraProps';
 import integer from './integer';
+import keysOf from './keysOf';
 import mutuallyExclusiveProps from './mutuallyExclusiveProps';
 import mutuallyExclusiveTrueProps from './mutuallyExclusiveTrueProps';
 import nChildren from './nChildren';
@@ -25,6 +26,7 @@ module.exports = {
   explicitNull,
   forbidExtraProps,
   integer,
+  keysOf,
   mutuallyExclusiveProps,
   mutuallyExclusiveTrueProps,
   nChildren,

--- a/src/keysOf.js
+++ b/src/keysOf.js
@@ -1,0 +1,35 @@
+export default function keysOf(validatorFn, name = 'keysOf') {
+  if (typeof validatorFn !== 'function') {
+    throw new TypeError('argument to keysOf must be a valid PropType');
+  }
+
+  const keysOfValidator = function keyedBy(props, propName, componentName, ...rest) {
+    if (props[propName] == null) {
+      return null; // not required
+    }
+    const keys = Object.keys(props[propName]);
+    let firstError = null;
+    keys.some((key) => {
+      const pseudoProps = { key };
+      firstError = validatorFn(pseudoProps, 'key', componentName, ...rest);
+      return firstError != null;
+    });
+    return firstError == null ? null : firstError;
+  };
+  keysOfValidator.typeName = name;
+
+  keysOfValidator.isRequired = function keyedByRequired(
+    props,
+    propName,
+    componentName,
+    ...rest
+  ) {
+    if (props[propName] == null) {
+      return new TypeError(`${propName} is required, but value is ${props[propName]}`);
+    }
+    return keysOfValidator(props, propName, componentName, ...rest);
+  };
+  keysOfValidator.isRequired.typeName = `${name}.isRequired`;
+
+  return keysOfValidator;
+}

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -10,6 +10,7 @@ module.exports = {
   explicitNull: noopThunk,
   forbidExtraProps: Object,
   integer: noopThunk,
+  keysOf: noopThunk,
   mutuallyExclusiveProps: noopThunk,
   mutuallyExclusiveTrueProps: noopThunk,
   nChildren: noopThunk,

--- a/test/keysOf.jsx
+++ b/test/keysOf.jsx
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import React, { PropTypes } from 'react';
+
+import { keysOf } from '../';
+
+import callValidator from './_callValidator';
+
+describe('keysOf', () => {
+  it('throws when not given a valid propType', () => {
+    expect(() => keysOf()).to.throw(TypeError);
+    expect(() => keysOf(null)).to.throw(TypeError);
+    expect(() => keysOf({})).to.throw(TypeError);
+    expect(() => keysOf([])).to.throw(TypeError);
+  });
+
+  it('returns a function', () => {
+    expect(typeof keysOf(PropTypes.any)).to.equal('function');
+  });
+
+  function assertPasses(validator, element, propName) {
+    expect(callValidator(validator, element, propName, '"keysOf" test')).to.equal(null);
+  }
+
+  function assertFails(validator, element, propName) {
+    expect(callValidator(validator, element, propName, '"keysOf" test')).to.be.instanceOf(Error);
+  }
+
+  it('passes with an object with no keys', () => {
+    assertPasses(
+      keysOf(PropTypes.number),
+      (<div a={{}} />),
+      'a',
+    );
+  });
+
+  it('passes when keys match the prop type', () => {
+    assertPasses(
+      keysOf(PropTypes.oneOf(['foo', 'bar'])),
+      (<div a={{ foo: 1, bar: 'qoob' }} />),
+      'a',
+    );
+  });
+
+  it('fails when keys do not match the prop type', () => {
+    assertFails(
+      keysOf(PropTypes.oneOf(['foo', 'bar'])),
+      (<div a={{ foo: 1, not_validated: 'qoob' }} />),
+      'a',
+    );
+  });
+
+  it('passes when the prop is not defined', () => {
+    assertPasses(
+      keysOf(PropTypes.number),
+      (<div />),
+      'a',
+    );
+  });
+
+  it('is required with .isRequired', () => {
+    assertFails(
+      keysOf(PropTypes.number).isRequired,
+      (<div />),
+      'a',
+    );
+  });
+
+  it('still passes with .isRequired if props are valid', () => {
+    assertPasses(
+      keysOf(PropTypes.oneOf(['foo', 'bar'])).isRequired,
+      (<div a={{ foo: 1, bar: 'qoob' }} />),
+      'a',
+    );
+  });
+});


### PR DESCRIPTION
It's quite common, especially when using Redux, to have an object property where the _keys_ should match a certain prop type, as well as the values. For instance:

* `locale -> data` where`locale`  is a two letter country code
* `id -> data` where `id` is an integer
* `email -> data` where `email` is a valid email

You probably want to be warned if an invalid key was passed in, because that means there's a bug somewhere. But since there are an unlimited number of valid keys in these cases, it's hard to generate a shape that covers all the bases.

This new proptype solves this by allowing you to specify a prop type that all keys must match - e.g.  `keyedByPropType(PropTypes.number)` or `keyedByPropType(PropTypes.oneOf(validValues))`. Used with `and`, it's possible to specify a proptype for both key and value, like so:

```js
const usernameByIdPropType = and([
  keyedByPropType(PropTypes.number),
  PropTypes.objectOf(PropTypes.string),
]).isRequired;
```

I'm using this in a few spots in our Redux app where we have properties that are keyed by ID or locale. I think it's pretty useful in general, so it would be awesome if this could live in `airbnb-prop-types`!