### PR TITLE
Adds regex capabilities to componentWithName

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Custom React PropType validators that we use at Airbnb.",
   "main": "index.js",
   "dependencies": {
-    "has": "^1.0.1"
+    "has": "^1.0.1",
+    "is-regex": "^1.0.4"
   },
   "devDependencies": {
     "airbnb-js-shims": "^1.1.1",

--- a/src/componentWithName.js
+++ b/src/componentWithName.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import isRegex from 'is-regex';
+
 import getComponentName from './helpers/getComponentName';
 import wrapValidator from './helpers/wrapValidator';
 
@@ -16,7 +18,15 @@ function hasName(name, prop, propName, componentName) {
   }
 
   const { type } = prop;
-  if (getComponentName(type) !== name) {
+  const componentNameFromType = getComponentName(type);
+
+  if (isRegex(name) && !name.test(componentNameFromType)) {
+    return new TypeError(
+      `\`${componentName}.${propName}\` only accepts components matching the regular expression ${name}`,
+    );
+  }
+
+  if (!isRegex(name) && componentNameFromType !== name) {
     return new TypeError(
       `\`${componentName}.${propName}\` only accepts components named ${name}`,
     );

--- a/test/componentWithName.jsx
+++ b/test/componentWithName.jsx
@@ -217,6 +217,48 @@ describe('componentWithName', () => {
     ));
   });
 
+  describe('when a regex value is provided instead of a string', () => {
+    it('passes with an SFC', () => assertPasses(
+      componentWithName(/FC$/),
+      (
+        <div><SFC default="Foo" /></div>
+      ),
+      'children',
+    ));
+
+    it('passes with an SFC + displayName', () => assertPasses(
+      componentWithName(/display name/),
+      (
+        <div><SFCwithName default="Foo" /></div>
+      ),
+      'children',
+    ));
+
+    it('passes with a Component', () => assertPasses(
+      componentWithName(/^Comp/),
+      (<div><Component default="Foo" /></div>),
+      'children',
+    ));
+
+    it('passes with a Component + displayName', () => assertPasses(
+      componentWithName(/display name/),
+      (<div><ComponentWithName default="Foo" /></div>),
+      'children',
+    ));
+
+    it('fails when SFC name does not match the regex provided', () => assertFails(
+      componentWithName(/foobar/),
+      (<div><SFC default="Foo" /></div>),
+      'children',
+    ));
+
+    it('fails when Component name does not match the regex provided', () => assertFails(
+      componentWithName(/foobar/),
+      (<div><Component default="Foo" /></div>),
+      'children',
+    ));
+  });
+
   it('fails when the provided prop is not a component', () => assertFails(
     componentWithName('SFC'),
     (


### PR DESCRIPTION
We have a need for a prop type that will validate a component name using regex. For instance, a particular type of component might accept any children of the form `*Row` or `*Card`. It made sense to me to add this ability to `componentWithName` directly, but am open to creating a new prop type as well. What do you think?

to: @ljharb @airbnb/webinfra 