### PR TITLE
`or`: fix so it works with `explicitNull`

### DIFF
--- a/src/or.js
+++ b/src/or.js
@@ -1,6 +1,38 @@
 import { PropTypes } from 'react';
 import wrapValidator from './helpers/wrapValidator';
 
+function oneOfTypeValidator(validators) {
+  const validator = function oneOfType(props, propName, componentName, ...rest) {
+    if (typeof props[propName] === 'undefined') {
+      return null;
+    }
+
+    const errors = validators
+      .map(v => v(props, propName, componentName, ...rest))
+      .filter(Boolean);
+
+    if (errors.length < validators.length) {
+      return null;
+    }
+    return new TypeError(`${componentName}: invalid value supplied to ${propName}.`);
+  };
+  validator.isRequired = function oneOfTypeRequired(props, propName, componentName, ...rest) {
+    if (typeof props[propName] === 'undefined') {
+      return new TypeError(`${componentName}: missing value for required ${propName}.`);
+    }
+
+    const errors = validators
+      .map(v => v(props, propName, componentName, ...rest))
+      .filter(Boolean);
+
+    if (errors.length === validators.length) {
+      return new TypeError(`${componentName}: invalid value ${errors} supplied to required ${propName}.`);
+    }
+    return null;
+  };
+  return wrapValidator(validator, 'oneOfType', validators);
+}
+
 export default function or(validators, name = 'or') {
   if (!Array.isArray(validators)) {
     throw new TypeError('or: 2 or more validators are required');
@@ -9,8 +41,8 @@ export default function or(validators, name = 'or') {
     throw new RangeError('or: 2 or more validators are required');
   }
 
-  const validator = PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType(validators)),
+  const validator = oneOfTypeValidator([
+    PropTypes.arrayOf(oneOfTypeValidator(validators)),
     ...validators,
   ]);
 

--- a/test/or.jsx
+++ b/test/or.jsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import React, { PropTypes } from 'react';
 
-import { or } from '../';
+import { or, explicitNull } from '../';
 
 import callValidator from './_callValidator';
 
@@ -50,5 +50,47 @@ describe('or', () => {
     assertFails(validator.isRequired, (<div a="b" />), 'a');
 
     assertFails(validator.isRequired, (<div />), 'a');
+  });
+
+  describe('works with explicitNull', () => {
+    it('works when outer and inner are optional', () => {
+      assertPasses(or([bool.isRequired, explicitNull()]), (<div a />), 'a');
+      assertPasses(or([bool.isRequired, explicitNull()]), (<div a={false} />), 'a');
+
+      assertPasses(or([bool.isRequired, explicitNull()]), (<div a={null} />), 'a');
+
+      assertPasses(or([bool.isRequired, explicitNull()]), (<div />), 'a');
+      assertPasses(or([bool.isRequired, explicitNull()]), (<div a={undefined} />), 'a');
+    });
+
+    it('works when outer is optional, inner is required', () => {
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]), (<div a />), 'a');
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]), (<div a={false} />), 'a');
+
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]), (<div a={null} />), 'a');
+
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]), (<div />), 'a');
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]), (<div a={undefined} />), 'a');
+    });
+
+    it('works when outer is required, inner is optional', () => {
+      assertPasses(or([bool.isRequired, explicitNull()]).isRequired, (<div a />), 'a');
+      assertPasses(or([bool.isRequired, explicitNull()]).isRequired, (<div a={false} />), 'a');
+
+      assertPasses(or([bool.isRequired, explicitNull()]).isRequired, (<div a={null} />), 'a');
+
+      assertFails(or([bool.isRequired, explicitNull()]).isRequired, (<div />), 'a');
+      assertFails(or([bool.isRequired, explicitNull()]).isRequired, (<div a={undefined} />), 'a');
+    });
+
+    it('works when outer is required, inner is required', () => {
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]).isRequired, (<div a />), 'a');
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]).isRequired, (<div a={false} />), 'a');
+
+      assertPasses(or([bool.isRequired, explicitNull().isRequired]).isRequired, (<div a={null} />), 'a');
+
+      assertFails(or([bool.isRequired, explicitNull().isRequired]).isRequired, (<div />), 'a');
+      assertFails(or([bool.isRequired, explicitNull().isRequired]).isRequired, (<div a={undefined} />), 'a');
+    });
   });
 });


### PR DESCRIPTION
Fixes #12.

This is a bit tricky; typically, propType validators have an early pass when optional and `propValue == null`, and an early failure when required and `propValue == null` - but that prevents `explicitNull` from working properly.

Thus, I kept the early pass/failure for `undefined`, but omitted it for `null` and delegated that responsibility to each individual propType validator. Thoughts?