### PR TITLE
Ensure childrenHavePropXorChildren validator skips over falsy children

### DIFF
--- a/src/childrenHavePropXorChildren.js
+++ b/src/childrenHavePropXorChildren.js
@@ -7,22 +7,29 @@ export default function childrenHavePropXorChildren(prop) {
   }
 
   const validator = function childrenHavePropXorChildrenWithProp({ children }, _, componentName) {
-    const childrenCount = React.Children.count(children);
+    let truthyChildrenCount = 0;
     let propCount = 0;
     let grandchildrenCount = 0;
 
     React.Children.forEach(children, (child) => {
+      if (!child) {
+        return;
+      }
+
+      truthyChildrenCount += 1;
+
       if (child.props[prop]) {
         propCount += 1;
       }
+
       if (React.Children.count(child.props.children)) {
         grandchildrenCount += 1;
       }
     });
 
     if (
-      (propCount === childrenCount && grandchildrenCount === 0) ||
-      (propCount === 0 && grandchildrenCount === childrenCount) ||
+      (propCount === truthyChildrenCount && grandchildrenCount === 0) ||
+      (propCount === 0 && grandchildrenCount === truthyChildrenCount) ||
       (propCount === 0 && grandchildrenCount === 0)
     ) {
       return null;

--- a/test/childrenHavePropXorChildren.jsx
+++ b/test/childrenHavePropXorChildren.jsx
@@ -68,6 +68,21 @@ describe('childrenHavePropXorChildren', () => {
       'ComponentName',
     ));
 
+    it('passes when falsy children are present and non-falsy children passes validator', () => assertPasses(
+      childrenHavePropXorChildren(prop),
+      (
+        <header>
+          <div />
+          <div />
+          {null}
+          {false}
+          {''}
+        </header>
+      ),
+      'abc',
+      'ComponentName',
+    ));
+
     it('fails when there is a mix of children and no children', () => assertFails(
       childrenHavePropXorChildren(prop),
       (
@@ -99,6 +114,21 @@ describe('childrenHavePropXorChildren', () => {
         <header>
           <div />
           <div {...{ [prop]: true }} />
+        </header>
+      ),
+      'abc',
+      'ComponentName',
+    ));
+
+    it('fails when falsy children are present and non-falsy children fails validator', () => assertFails(
+      childrenHavePropXorChildren(prop),
+      (
+        <header>
+          <div />
+          <div {...{ [prop]: true }} />
+          {null}
+          {false}
+          {''}
         </header>
       ),
       'abc',


### PR DESCRIPTION
@ljharb If you can help review that'd be great!

Added fix + relevant tests

Fixes #18.