### PR TITLE
Change API of mutuallyExclusiveProps to allow different prop types

### DIFF
--- a/src/mutuallyExclusiveProps.js
+++ b/src/mutuallyExclusiveProps.js
@@ -1,6 +1,6 @@
 import wrapValidator from './helpers/wrapValidator';
 
-export default function mutuallyExclusiveOfType(propType, ...exclusiveProps) {
+function mutuallyExclusiveOfType(propType, ...exclusiveProps) {
   if (typeof propType !== 'function') {
     throw new TypeError('a propType is required');
   }
@@ -14,7 +14,7 @@ export default function mutuallyExclusiveOfType(propType, ...exclusiveProps) {
   const map = exclusiveProps.reduce((acc, prop) => ({ ...acc, [prop]: true }), {});
   const countProps = (count, prop) => (count + (map[prop] ? 1 : 0));
 
-  const validator = function mutuallyExclusiveProps(props, propName, componentName, ...rest) {
+  const validator = function mutuallyExclusiveOfTypeProps(props, propName, componentName, ...rest) {
     const exclusivePropCount = Object.keys(props)
       .filter(prop => props[prop] != null)
       .reduce(countProps, 0);
@@ -37,6 +37,53 @@ export default function mutuallyExclusiveOfType(propType, ...exclusiveProps) {
       return new Error(`A ${componentName} cannot have more than one of these props: ${propList}`);
     }
     return propType(props, propName, componentName, ...rest);
+  };
+
+  return wrapValidator(validator, `mutuallyExclusiveProps:${propList}`, exclusiveProps);
+}
+
+export default function mutuallyExclusive(exclusiveProps) {
+  if (typeof exclusiveProps === 'function') {
+    return mutuallyExclusiveOfType(...arguments); // eslint-disable-line prefer-rest-params
+  }
+
+  if (Object.keys(exclusiveProps).length < 1) {
+    throw new TypeError('at least one prop that is mutually exclusive with this propType is required');
+  }
+
+  const propList = Object.keys(exclusiveProps).join(', or ');
+
+  const countProps = (count, prop) => (count + (exclusiveProps[prop] ? 1 : 0));
+
+  const validator = function mutuallyExclusiveProps(props, propName, componentName, ...rest) {
+    const exclusivePropCount = Object.keys(props)
+      .filter(prop => props[prop] != null)
+      .reduce(countProps, 0);
+    if (exclusivePropCount > 1) {
+      return new Error(`A ${componentName} cannot have more than one of these props: ${propList}`);
+    }
+    if (exclusiveProps[propName] == null) {
+      return null;
+    }
+    return exclusiveProps[propName](props, propName, componentName, ...rest);
+  };
+
+  validator.isRequired = function mutuallyExclusivePropsRequired(
+    props,
+    propName,
+    componentName,
+    ...rest
+  ) {
+    const exclusivePropCount = Object.keys(props)
+      .filter(prop => prop === propName || props[prop] != null)
+      .reduce(countProps, 0);
+    if (exclusivePropCount > 1) {
+      return new Error(`A ${componentName} cannot have more than one of these props: ${propList}`);
+    }
+    if (exclusiveProps[propName] == null) {
+      return null;
+    }
+    return exclusiveProps[propName](props, propName, componentName, ...rest);
   };
 
   return wrapValidator(validator, `mutuallyExclusiveProps:${propList}`, exclusiveProps);


### PR DESCRIPTION
This modifies `mutuallyExclusiveProps` to define mutually exclusive props with different prop types. For example:

```
const iconOrImageUrl = mutuallyExclusiveProps({
  icon: iconProp,
  imageUrl: PropTypes.string,
});
```

I did this whilst allowing the old API to work, but I feel like something should be done to remove the old API. Let me know what your thoughts are about this...

@ljharb @backwardok 