### PR TITLE
Upgraded react dependency to 16.0.0-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ sudo: false
 env:
   - REACT=14
   - REACT=15
+  - REACT=16
 matrix:
   fast_finish: true
   include:

--- a/install-relevant-react.sh
+++ b/install-relevant-react.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-REACT=${REACT:-15}
+REACT=${REACT:-16}
 
 echo "installing React $REACT"
 
@@ -10,4 +10,8 @@ fi
 
 if [ "$REACT" = "15" ]; then
     npm run react:15
+fi
+
+if [ "$REACT" = "16" ]; then
+    npm run react:16
 fi

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "mocha": "^3.4.2",
     "nyc": "^10.3.2",
     "object.values": "^1.0.4",
-    "react": "^15.6.1",
+    "react": "^16.0.0-alpha.12",
     "reflect.ownkeys": "^0.2.0",
     "rimraf": "^2.6.1",
     "safe-publish-latest": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15.0.0"
+    "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
   },
   "scripts": {
     "pretest": "npm run lint",
@@ -55,7 +55,8 @@
     "mocha": "mocha --recursive test/helpers/_failTestsOnErrors",
     "react:clean": "rimraf node_modules/react node_modules/react-dom node_modules/react-addons-test-utils",
     "react:14": "npm run react:clean && npm i --no-save react@0.14 react-dom@0.14 react-addons-test-utils@0.14",
-    "react:15": "npm run react:clean && npm i --no-save react@15 react-dom@15 react-addons-test-utils@15"
+    "react:15": "npm run react:clean && npm i --no-save react@15 react-dom@15 react-addons-test-utils@15",
+    "react:16": "npm run react:clean && npm i --no-save react@16.0.0-alpha.12 react-dom@16.0.0-alpha.12 react-addons-test-utils@16.0.0-alpha.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
React Native 0.45 uses react 16.0.0-alpha.12 so this is required as one of many steps to upgrade to RN 0.45.

`npm run test` succeeded. Is anything else necessary?

@lelandrichardson @ljharb 