### PR TITLE
Make `getComponentName` more robust in IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "array.prototype.find": "^2.0.4",
+    "function.prototype.name": "^1.0.1",
     "has": "^1.0.1",
     "is-regex": "^1.0.4",
     "object.assign": "^4.0.4",

--- a/src/helpers/getComponentName.js
+++ b/src/helpers/getComponentName.js
@@ -1,10 +1,11 @@
+import getFunctionName from 'function.prototype.name';
+
 export default function getComponentName(Component) {
   if (typeof Component === 'string') {
     return Component;
   }
   if (typeof Component === 'function') {
-    const { displayName, name } = Component;
-    return displayName || name;
+    return Component.displayName || getFunctionName(Component);
   }
   return null;
 }


### PR DESCRIPTION
Per our discussion, `getComponentName` will be bulletproof against IE11 less along with the [browser shim](https://github.com/airbnb/browser-shims/pull/15)