### PR TITLE
[New] add `uniqueArrayWithMapper`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import restrictedProp from './restrictedProp';
 import sequenceOf from './sequenceOf';
 import shape from './shape';
 import uniqueArray from './uniqueArray';
+import uniqueArrayWithMapper from './uniqueArrayWithMapper';
 import uniqueArrayOf from './uniqueArrayOf';
 import valuesOf from './valuesOf';
 import withShape from './withShape';
@@ -54,6 +55,7 @@ module.exports = {
   sequenceOf,
   shape,
   uniqueArray,
+  uniqueArrayWithMapper,
   uniqueArrayOf,
   valuesOf,
   withShape,

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -28,6 +28,7 @@ module.exports = {
   sequenceOf: noopThunk,
   shape: noopThunk,
   uniqueArray: noopThunk,
+  uniqueArrayWithMapper: noopThunk,
   uniqueArrayOf: noopThunk,
   valuesOf: noopThunk,
   withShape: noopThunk,

--- a/src/uniqueArrayWithMapper.js
+++ b/src/uniqueArrayWithMapper.js
@@ -26,7 +26,7 @@ function uniqueArrayWithMapperValidator(mapper) {
 
   uniqueArrayMapped.isRequired = function isRequired(props, propName, ...rest) {
     const propValue = props[propName];
-    if (propValue == null) {
+    if (propValue === undefined) {
       return array.isRequired(props, propName, ...rest);
     }
     return uniqueArrayMapped(props, propName, ...rest);

--- a/src/uniqueArrayWithMapper.js
+++ b/src/uniqueArrayWithMapper.js
@@ -1,0 +1,41 @@
+import { array } from 'prop-types';
+import uniqueArray from './uniqueArray';
+import wrapValidator from './helpers/wrapValidator';
+
+const unique = uniqueArray();
+
+function uniqueArrayWithMapperValidator(mapper) {
+  if (typeof mapper !== 'function') {
+    throw new TypeError('mapper must be a mapper function');
+  }
+
+  function uniqueArrayMapped(props, propName, ...rest) {
+    const propValue = props[propName];
+    if (propValue === undefined) {
+      return null;
+    }
+
+    const result = array.isRequired(props, propName, ...rest);
+    if (result !== null) {
+      return result;
+    }
+
+    const values = propValue.map(mapper);
+    return unique({ ...props, [propName]: values }, propName, ...rest);
+  }
+
+  uniqueArrayMapped.isRequired = function isRequired(props, propName, ...rest) {
+    const propValue = props[propName];
+    if (propValue == null) {
+      return array.isRequired(props, propName, ...rest);
+    }
+    return uniqueArrayMapped(props, propName, ...rest);
+  };
+
+  return uniqueArrayMapped;
+}
+
+export default (mapper = null) => (
+  wrapValidator(uniqueArrayWithMapperValidator(mapper), 'uniqueArrayWithMapper')
+);
+

--- a/test/uniqueArrayWithMapper.jsx
+++ b/test/uniqueArrayWithMapper.jsx
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import React from 'react';
+
+import { uniqueArrayWithMapper } from '../';
+
+import callValidator from './_callValidator';
+
+describe('uniqueArrayWithMapper', () => {
+  function identityMapper(element) { return element; }
+  function constantMapper(element) { return element ** 0; }
+  function objectMapper(element) { return element.exampleKey; }
+
+  it('returns a function', () => {
+    expect(typeof uniqueArrayWithMapper(identityMapper)).to.equal('function');
+  });
+
+  function assertPasses(validator, element, propName) {
+    expect(callValidator(validator, element, propName, '"uniqueArrayWithMapper" test')).to.equal(null);
+  }
+
+  function assertFails(validator, element, propName) {
+    expect(callValidator(validator, element, propName, '"uniqueArrayWithMapper" test')).to.be.instanceOf(Error);
+  }
+
+  it('requires an array', () => assertFails(
+    uniqueArrayWithMapper(identityMapper),
+    (<div foo="bar" />),
+    'foo',
+  ));
+
+  it('is not required by default', () => assertPasses(
+    uniqueArrayWithMapper(identityMapper),
+    (<div foo={[1, 2]} />),
+    'missing',
+  ));
+
+  it('throws if not given a function', () => {
+    expect(() => uniqueArrayWithMapper()).to.throw(TypeError);
+    expect(() => uniqueArrayWithMapper(undefined)).to.throw(TypeError);
+    expect(() => uniqueArrayWithMapper(null)).to.throw(TypeError);
+    expect(() => uniqueArrayWithMapper([])).to.throw(TypeError);
+    expect(() => uniqueArrayWithMapper({})).to.throw(TypeError);
+    expect(() => uniqueArrayWithMapper('')).to.throw(TypeError);
+    expect(() => uniqueArrayWithMapper(42)).to.throw(TypeError);
+    expect(() => uniqueArrayWithMapper(NaN)).to.throw(TypeError);
+  });
+
+  it('is required with .isRequired', () => assertFails(
+    uniqueArrayWithMapper(identityMapper).isRequired,
+    (<div foo="bar" />),
+    'missing',
+  ));
+
+  it('enforces uniqueness', () => {
+    assertFails(
+      uniqueArrayWithMapper(identityMapper),
+      (<div foo={[3, 1, 2, 3, 4]} />),
+      'foo',
+    );
+    assertPasses(
+      uniqueArrayWithMapper(identityMapper),
+      (<div foo={[1, 2, 3, 4]} />),
+      'foo',
+    );
+    assertFails(
+      uniqueArrayWithMapper(constantMapper),
+      (<div foo={[1, 2, 3, 4]} />),
+      'foo',
+    );
+  });
+
+  it('enforces uniqueness of objects too', () => {
+    assertFails(
+      uniqueArrayWithMapper(objectMapper),
+      (<div foo={[{ exampleKey: 1, otherKey: 2 }, { exampleKey: 1, otherKey: 3 }]} />),
+      'foo',
+    );
+    assertPasses(
+      uniqueArrayWithMapper(objectMapper),
+      (<div foo={[{ exampleKey: 1, otherKey: 2 }, { exampleKey: 2, otherKey: 2 }]} />),
+      'foo',
+    );
+  });
+});


### PR DESCRIPTION
Added a new propType `uniqueArrayWithMapper`: `uniqueArray`, with an additional function parameter that allows for a non-standard unique calculation (`Object.is`). The function is applied to each element in the array, and the resulting values are compared using the standard unique calculation.