### PR TITLE
[New] add optional `mapper` function to `uniqueArrayOf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Custom React PropType validators that we use at Airbnb. Use of [airbnb-js-shims]
  - `sequenceOf`: takes 1 or more "specifiers": an object with a "validator" function (a propType validator), a "min" nonNegativeInteger, and a "max" nonNegativeInteger. If both "min" and "max" may be omitted, they default to 1; if only "max" is omitted, it defaults to Infinity; if only "min" is omitted, it defaults to 1.
  - `shape`: takes a shape, and allows it to be enforced on any non-null/undefined value.
  - `uniqueArray`: this prop must be an array, and all values must be unique (determined by `Object.is`). Like `PropTypes.array`, but with uniqueness.
- - `uniqueArrayOf`: `uniqueArray`, with a type validator applied. Like `PropTypes.arrayOf`, but with uniqueness.
+ - `uniqueArrayOf`: `uniqueArray`, with a type validator applied. Like `PropTypes.arrayOf`, but with uniqueness. Can also take an optional mapper function that allows for a non-standard unique calculation (otherwise, `Object.is` is used by default). The function is applied to each element in the array, and the resulting values are compared using the standard unique calculation.
  - `valuesOf`: a non-object requiring `PropTypes.objectOf`. Takes a propType validator, and applies it to every own value on the propValue.
  - `withShape`: takes a PropType and a shape, and allows it to be enforced on any non-null/undefined value.
 

--- a/src/uniqueArrayOf.js
+++ b/src/uniqueArrayOf.js
@@ -1,20 +1,62 @@
-import { arrayOf } from 'prop-types';
+import { arrayOf, array } from 'prop-types';
 import and from './and';
 import uniqueArray from './uniqueArray';
 
 const unique = uniqueArray();
 
-export default function uniqueArrayOfTypeValidator(type, name = 'uniqueArrayOfType') {
+export default function uniqueArrayOfTypeValidator(type, ...rest) {
   if (typeof type !== 'function') {
     throw new TypeError('type must be a validator function');
   }
 
+  let mapper = null;
+  let name = 'uniqueArrayOfType';
+
+  if (rest.length === 1) {
+    if (typeof rest[0] === 'function') {
+      mapper = rest[0];
+    } else if (typeof rest[0] === 'string') {
+      name = rest[0];
+    } else {
+      throw new TypeError('single input must either be string or function');
+    }
+  } else if (rest.length === 2) {
+    if (typeof rest[0] === 'function' && typeof rest[1] === 'string') {
+      mapper = rest[0];
+      name = rest[1];
+    } else {
+      throw new TypeError('multiple inputs must be in [function, string] order');
+    }
+  } else if (rest.length > 2) {
+    throw new TypeError('only [], [name], [mapper], and [mapper, name] are valid inputs');
+  }
+
+  function uniqueArrayOfMapped(props, propName, ...args) {
+    const propValue = props[propName];
+    if (propValue == null) {
+      return null;
+    }
+
+    const values = propValue.map(mapper);
+    return unique({ ...props, [propName]: values }, propName, ...args);
+  }
+
+  uniqueArrayOfMapped.isRequired = function isRequired(props, propName, ...args) {
+    const propValue = props[propName];
+    if (propValue == null) {
+      return array.isRequired(props, propName, ...args);
+    }
+    return uniqueArrayOfMapped(props, propName, ...args);
+  };
+
   const arrayValidator = arrayOf(type);
 
-  const validator = and([arrayValidator, unique], name);
+  const uniqueValidator = mapper ? uniqueArrayOfMapped : unique;
+
+  const validator = and([arrayValidator, uniqueValidator], name);
   validator.isRequired = and([
+    uniqueValidator.isRequired,
     arrayValidator.isRequired,
-    unique.isRequired,
   ], `${name}.isRequired`);
 
   return validator;


### PR DESCRIPTION
Added new propType `uniqueArrayWithMapper`: `uniqueArray`, with an additional function parameter that allows for a non-standard unique calculation (`Object.is`). The function is applied to each element in the array, and the resulting values are compared using the standard unique calculation.