### PR TITLE
add requiredBy validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Custom React PropType validators that we use at Airbnb. Use of [airbnb-js-shims]
  - `object`: same as `PropTypes.object`, but can be called outside of React's propType flow.
  - `or`: recursively allows only the provided propTypes, or arrays of those propTypes.
  - `range`: provide a min, and a max, and the prop must be a number in the range `[min, max)`
+ - `requiredBy`: pass in a prop name and propType, and require that the prop is defined and is not its default value if the passed in prop name is truthy. if the default value is not provided, defaults to checking against `null`.
  - `restrictedProp`: this prop is not permitted to be anything but `null` or `undefined`.
  - `sequenceOf`: takes 1 or more "specifiers": an object with a "validator" function (a propType validator), a "min" nonNegativeInteger, and a "max" nonNegativeInteger. If both "min" and "max" may be omitted, they default to 1; if only "max" is omitted, it defaults to Infinity; if only "min" is omitted, it defaults to 1.
  - `shape`: takes a shape, and allows it to be enforced on any non-null/undefined value.

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import numericString from './numericString';
 import object from './object';
 import or from './or';
 import range from './range';
+import requiredBy from './requiredBy';
 import restrictedProp from './restrictedProp';
 import sequenceOf from './sequenceOf';
 import shape from './shape';
@@ -50,6 +51,7 @@ module.exports = {
   object,
   or,
   range,
+  requiredBy,
   restrictedProp,
   sequenceOf,
   shape,

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -24,6 +24,7 @@ module.exports = {
   object: noopThunk,
   or: noopThunk,
   range: noopThunk,
+  requiredBy: noopThunk,
   restrictedProp: noopThunk,
   sequenceOf: noopThunk,
   shape: noopThunk,

--- a/src/requiredBy.js
+++ b/src/requiredBy.js
@@ -1,7 +1,8 @@
 export default function requiredBy(requiredByPropName, propType, defaultValue = null) {
   return function validator(props, propName, componentName, ...rest) {
     if (props[requiredByPropName]) {
-      if (props[propName] === defaultValue || typeof props[propName] === 'undefined') {
+      const propValue = props[propName];
+      if (Object.is(propValue, defaultValue) || typeof propValue === 'undefined') {
         return new TypeError(
           `${componentName}: when ${requiredByPropName} is true, prop “${propName}” must be present.`,
         );

--- a/src/requiredBy.js
+++ b/src/requiredBy.js
@@ -1,0 +1,12 @@
+export default function requiredBy(requiredByPropName, propType, defaultValue = null) {
+  return function validator(props, propName, componentName, ...rest) {
+    if (props[requiredByPropName]) {
+      if (props[propName] === defaultValue || typeof props[propName] === 'undefined') {
+        return new TypeError(
+          `${componentName}: when ${requiredByPropName} is true, prop “${propName}” must be present.`,
+        );
+      }
+    }
+    return propType(props, propName, componentName, ...rest);
+  };
+}

--- a/test/requiredBy.jsx
+++ b/test/requiredBy.jsx
@@ -22,11 +22,13 @@ describe('requiredBy propTypes', () => {
     it('passes when the prop that the requiredBy prop needs is passed in', () => {
       assertPasses(requiredBy('bar', bool), (<div bar foo />), 'foo');
       assertPasses(requiredBy('bar', number, 42), (<div bar foo={3} />), 'foo');
+      assertPasses(requiredBy('bar', number, NaN), (<div bar foo={42} />), 'foo');
     });
 
     it('fails when the prop the requiredBy prop needs matches the defaultValue', () => {
       assertFails(requiredBy('bar', number, 42), (<div bar foo={42} />), 'foo');
       assertFails(requiredBy('bar', number, 0), (<div bar foo={0} />), 'foo');
+      assertFails(requiredBy('bar', number, NaN), (<div bar foo={NaN} />), 'foo');
     });
 
     it('fails when the prop the requiredBy prop needs has the wrong prop type', () => {

--- a/test/requiredBy.jsx
+++ b/test/requiredBy.jsx
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import React from 'react';
+import { bool, number } from 'prop-types';
+
+import { requiredBy } from '../';
+import callValidator from './_callValidator';
+
+function assertPasses(validator, element, propName) {
+  expect(callValidator(validator, element, propName, '"requiredBy" test')).to.equal(null);
+}
+
+function assertFails(validator, element, propName) {
+  expect(callValidator(validator, element, propName, '"requiredBy" test')).to.be.instanceOf(Error);
+}
+
+describe('requiredBy propTypes', () => {
+  describe('passed prop name into requiredBy exists', () => {
+    it('passes when no props are present', () => {
+      assertPasses(requiredBy('bar', bool), (<div bar={null} foo={null} />), 'foo');
+    });
+
+    it('passes when the prop that the requiredBy prop needs is passed in', () => {
+      assertPasses(requiredBy('bar', bool), (<div bar foo />), 'foo');
+      assertPasses(requiredBy('bar', number, 42), (<div bar foo={3} />), 'foo');
+    });
+
+    it('fails when the prop the requiredBy prop needs matches the defaultValue', () => {
+      assertFails(requiredBy('bar', number, 42), (<div bar foo={42} />), 'foo');
+      assertFails(requiredBy('bar', number, 0), (<div bar foo={0} />), 'foo');
+    });
+
+    it('fails when the prop the requiredBy prop needs has the wrong prop type', () => {
+      assertFails(requiredBy('bar', bool), (<div bar foo="wrong" />), 'foo');
+    });
+
+    it('fails when the prop the requiredBy prop needs does not exist', () => {
+      assertFails(requiredBy('bar', bool), (<div bar />), 'foo');
+    });
+  });
+
+  describe('passed prop name into requiredBy does not exist', () => {
+    it('passes when the prop the required prop needs is passed in', () => {
+      assertPasses(requiredBy('bar', bool), (<div foo />), 'foo');
+    });
+
+    it('passes when the prop the required prop needs does not exist', () => {
+      assertPasses(requiredBy('bar', bool), (<div foo />), 'foo');
+    });
+  });
+});


### PR DESCRIPTION
`requiredBy`: pass in a prop name and propType, and require that the prop is defined and is not its default value if the passed in prop name is truthy. if the default value is not provided, defaults to checking against `null`.

### Example:
```
const onFooButtonPressDefault = () => {};
const propTypes = {
  fooButtonText: requiredBy('showFoo', PropTypes.string),
  onFooButtonPress: requiredBy('showFoo', PropTypes.func, onFooButtonPressDefault),
  showFooButton: PropTypes.bool,
};

const defaultProps = {
  fooButtonText: null,
  onFooButtonPress: onFooButtonPressDefault,
  showFooButton: false,
};
```
#### Passes validator
```
<MyComponent
  fooButtonText="text"
  onFooButtonPress={this.handleFooButtonPress}
  showFooButton
/>
```
#### Does not pass validator
```
<MyComponent
  fooButtonText={4}
  onFooButtonPress={this.handleFooButtonPress}
  showFooButton
/>
<MyComponent
  onFooButtonPress={this.handleFooButtonPress}
  showFooButton
/>
<MyComponent
  fooButtonText="text"
  showFooButton
/>
<MyComponent showFooButton />
```