### PR TITLE
feat(url-prop-type): add URL prop type

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "function.prototype.name": "^1.0.3",
     "has": "^1.0.1",
     "is-regex": "^1.0.4",
+    "is-url": "^1.2.2",
     "object-is": "^1.0.1",
     "object.assign": "^4.0.4",
     "object.entries": "^1.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import sequenceOf from './sequenceOf';
 import shape from './shape';
 import uniqueArray from './uniqueArray';
 import uniqueArrayOf from './uniqueArrayOf';
+import url from './url';
 import valuesOf from './valuesOf';
 import withShape from './withShape';
 
@@ -57,6 +58,7 @@ module.exports = {
   shape,
   uniqueArray,
   uniqueArrayOf,
+  url,
   valuesOf,
   withShape,
 };

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -30,6 +30,7 @@ module.exports = {
   shape: noopThunk,
   uniqueArray: noopThunk,
   uniqueArrayOf: noopThunk,
+  url: noopThunk,
   valuesOf: noopThunk,
   withShape: noopThunk,
 };

--- a/src/url.js
+++ b/src/url.js
@@ -1,0 +1,32 @@
+import isURL from 'is-url';
+import PropTypes from 'prop-types';
+
+import wrapValidator from './helpers/wrapValidator';
+
+function requiredURL(props, propName, componentName, ...rest) {
+  const stringError = PropTypes.string.isRequired(props, propName, componentName, ...rest);
+
+  if (stringError) {
+    return stringError;
+  }
+
+  const value = props[propName];
+
+  if (!value.startsWith('/') && !isURL(value)) {
+    return new TypeError(`${propName} in ${componentName} must be a valid URL; value is ${value}`);
+  }
+
+  return null;
+}
+
+const validator = function url(props, propName, ...rest) {
+  if (props[propName] == null) {
+    return null;
+  }
+
+  return requiredURL(props, propName, ...rest);
+};
+
+validator.isRequired = requiredURL;
+
+export default () => wrapValidator(validator, 'url');

--- a/test/url.jsx
+++ b/test/url.jsx
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import React from 'react';
+
+import { url } from '../';
+
+import callValidator from './_callValidator';
+
+describe('url', () => {
+  const validAbsoluteURL = 'https://www.airbnb.com';
+  const validRelativeURL = '/foobar';
+  const invalidURL = 'foobar';
+  const componentName = 'url test';
+  const propName = 'urlProp';
+
+  it('returns a function', () => {
+    expect(typeof url()).to.equal('function');
+  });
+
+  function assertPasses(validator, element) {
+    expect(callValidator(validator, element, propName, componentName)).to.equal(null);
+  }
+
+  function assertFails(validator, element) {
+    expect(callValidator(validator, element, propName, componentName)).to.be.instanceOf(Error);
+  }
+
+  function getElementWithURLPropValue(value) {
+    return (<div urlProp={value} />);
+  }
+
+  it('passes on null values', () => {
+    assertPasses(url(), getElementWithURLPropValue(undefined));
+    assertPasses(url(), getElementWithURLPropValue(null));
+  });
+
+  it('passes on a valid url', () => {
+    const element = getElementWithURLPropValue(validAbsoluteURL);
+    assertPasses(url(), element);
+    assertPasses(url().isRequired, element);
+  });
+
+  it('passes on a valid relative-absolute url', () => {
+    const element = getElementWithURLPropValue(validRelativeURL);
+    assertPasses(url(), element);
+    assertPasses(url().isRequired, element);
+  });
+
+  it('fails for a non-string value', () => {
+    const element = getElementWithURLPropValue(1);
+    assertFails(url(), element);
+    assertFails(url().isRequired, element);
+  });
+
+  it('fails on an invalid url', () => {
+    const element = getElementWithURLPropValue(invalidURL);
+    assertFails(url(), element);
+    assertFails(url().isRequired, element);
+  });
+
+  describe('isRequired', () => {
+    const elementWithoutURLProp = (<div />);
+
+    it('passes when not required', () => assertPasses(url(), elementWithoutURLProp));
+    it('fails when required', () => assertFails(url().isRequired, elementWithoutURLProp));
+  });
+});


### PR DESCRIPTION
# Description
Adding validation for props that represent URL values might be more useful than using `PropTypes.string`.

Depends on [the `is-url` package](https://www.npmjs.com/package/is-url).