### PR TITLE
[New] Add disallowedIf PropType

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Custom React PropType validators that we use at Airbnb. Use of [airbnb-js-shims]
  - `componentWithName`: restrict the prop to only allow a component with a certain name/displayName. Accepts a string, or a regular expression. Also accepts an `options` object with an optional `stripHOCs` array of string HOC names to strip off before validating; an HOC name must not contain parentheses and must be in camelCase.
    - `foo: componentWithName('Component')`
    - `foo: componentWithName('Component', { stripHOCs: ['withDirection', 'withStyles'] })`
+ - `disallowedIf`: restrict the prop from being provided if the given other prop name matches the given other prop type.
+   - `foo: disallowedIf(string, 'bar', bool)`
  - `elementType`: require that the prop be a specific type of React element - takes a Component, an HTML tag name, or `"*"` to match everything.
    - `foo: elementType('span')`
    - `foo: elementType(Component)`

--- a/src/disallowedIf.js
+++ b/src/disallowedIf.js
@@ -1,0 +1,43 @@
+import wrapValidator from './helpers/wrapValidator';
+
+export default function disallowedIf(propType, otherPropName, otherPropType) {
+  if (typeof propType !== 'function' || typeof propType.isRequired !== 'function') {
+    throw new TypeError('a propType validator is required; propType validators must also provide `.isRequired`');
+  }
+
+  if (typeof otherPropName !== 'string') {
+    throw new TypeError('other prop name must be a string');
+  }
+
+  if (typeof otherPropType !== 'function') {
+    throw new TypeError('other prop type validator is required');
+  }
+
+  function disallowedIfRequired(props, propName, componentName, ...rest) {
+    const error = propType.isRequired(props, propName, componentName, ...rest);
+    if (error) {
+      return error;
+    }
+
+    if (props[otherPropName] == null) {
+      return null;
+    }
+
+    const otherError = otherPropType(props, otherPropName, componentName, ...rest);
+    if (otherError) {
+      return null;
+    }
+    return new Error(`prop “${propName}” is disallowed when “${otherPropName}” matches the provided validator`);
+  }
+
+  const validator = function disallowedIfPropType(props, propName, ...rest) {
+    if (props[propName] == null) {
+      return null;
+    }
+    return disallowedIfRequired(props, propName, ...rest);
+  };
+
+  validator.isRequired = disallowedIfRequired;
+
+  return wrapValidator(validator, 'disallowedIf', { propType, otherPropName, otherPropType });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import childrenOf from './childrenOf';
 import childrenOfType from './childrenOfType';
 import childrenSequenceOf from './childrenSequenceOf';
 import componentWithName from './componentWithName';
+import disallowedIf from './disallowedIf';
 import elementType from './elementType';
 import explicitNull from './explicitNull';
 import integer from './integer';
@@ -40,6 +41,7 @@ module.exports = {
   childrenOfType,
   childrenSequenceOf,
   componentWithName,
+  disallowedIf,
   elementType,
   explicitNull,
   forbidExtraProps,

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -11,6 +11,7 @@ module.exports = {
   childrenOfType: noopThunk,
   childrenSequenceOf: noopThunk,
   componentWithName: noopThunk,
+  disallowedIf: noopThunk,
   elementType: noopThunk,
   explicitNull: noopThunk,
   forbidExtraProps: Object,

--- a/test/disallowedIf.jsx
+++ b/test/disallowedIf.jsx
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import { any, bool } from 'prop-types';
+import React from 'react';
+
+import { disallowedIf } from '../';
+
+import callValidator from './_callValidator';
+
+describe('disallowedIf', () => {
+  it('throws when not given proper arguments', () => {
+    expect(() => disallowedIf(null, 'other', any)).to.throw(TypeError);
+    expect(() => disallowedIf(any, 'other')).to.throw(TypeError);
+    expect(() => disallowedIf(any, null, any)).to.throw(TypeError);
+  });
+
+  it('returns a function', () => {
+    expect(typeof disallowedIf(any, 'other', any)).to.equal('function');
+  });
+
+  function assertPasses(validator, element, propName) {
+    expect(callValidator(validator, element, propName)).to.equal(null);
+  }
+
+  function assertFails(validator, element, propName) {
+    expect(callValidator(validator, element, propName)).to.be.instanceOf(Error);
+  }
+
+  it('passes when the other prop is null or undefined', () => {
+    assertPasses(
+      disallowedIf(bool, 'b', any),
+      (<div a />),
+      'a',
+    );
+  });
+
+  it('passes when the other prop does not match the specified type', () => {
+    assertPasses(
+      disallowedIf(bool, 'b', bool),
+      (<div a b="string" />),
+      'a',
+    );
+  });
+
+  it('passes when the other prop matches the specified type and the prop is not provided', () => {
+    assertPasses(
+      disallowedIf(bool, 'b', bool),
+      (<div b="string" />),
+      'a',
+    );
+  });
+
+  it('fails when the other prop matches the specified type', () => {
+    assertFails(
+      disallowedIf(bool, 'b', bool),
+      (<div a b={false} />),
+      'a',
+    );
+  });
+
+  it('fails when the provided propType fails', () => {
+    assertFails(
+      disallowedIf(bool, 'b', bool),
+      (<div a="string" b="other string" />),
+      'a',
+    );
+  });
+
+  it('fails when required and not provided', () => {
+    assertFails(
+      disallowedIf(bool, 'b', bool).isRequired,
+      (<div b="other string" />),
+      'a',
+    );
+  });
+});


### PR DESCRIPTION
`disallowedIf`: wraps a proptype and accepts another prop name and another prop type. If the other prop is provided and matches the given type, the validator fails. Functionally similar to `mutuallyExclusiveProps` and `mutallyExclusivePropTypes` but is more flexible in the type being compared (although less flexible in the number of props that can be compared).

## Example usage
```
const propTypes = {
  other: PropTypes.oneOf(['bar', 'baz']),
  foo: disallowedIf(PropTypes.string, 'other', PropTypes.oneOf(['bar'])),
};

const defaultProps = {
  other: 'baz',
  foo: null,
};
```
### Pass
```
<MyComponent foo="Hello" />

<MyComponent foo="Hello" other="baz" />
```

### Fail
```
<MyComponent foo="Hello" other="bar" />
```