### PR TITLE
Add ref prop type

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ Custom React PropType validators that we use at Airbnb. Use of [airbnb-js-shims]
    - `children: nChildren(3)`
    - `children: nChildren(3, childrenOfType('span'))`
  - `nonNegativeInteger`: require that the prop be a number, that is 0, or a finite positive integer.
-   - `foo: nonNegativeInteger`
+   - `foo: nonNegativeInteger()`
  - `nonNegativeNumber`: require that the prop be a number, that is 0, or a finite positive number.
-   - `foo: nonNegativeNumber`
+   - `foo: nonNegativeNumber()`
  - `numericString`: require the prop be a string that is conceptually numeric.
-   - `foo: numericString`
+   - `foo: numericString()`
  - `object`: same as `PropTypes.object`, but can be called outside of React's propType flow.
  - `or`: recursively allows only the provided propTypes, or arrays of those propTypes.
    - `foo: or([bool.isRequired, explicitNull()])`
  - `range`: provide a min, and a max, and the prop must be an integer in the range `[min, max)`
    - `foo: range(-1, 2)`
+ - `ref`: require the prop to be a React ref. These can be either the object returned from `React.createRef()` or "callback" refs.
+   - `foo: ref()`
  - `requiredBy`: pass in a prop name and propType, and require that the prop is defined and is not its default value if the passed in prop name is truthy. if the default value is not provided, defaults to checking against `null`.
    - `foo: requiredBy('bar', bool)`
  - `restrictedProp`: this prop is not permitted to be anything but `null` or `undefined`.

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import numericString from './numericString';
 import object from './object';
 import or from './or';
 import range from './range';
+import ref from './ref';
 import requiredBy from './requiredBy';
 import restrictedProp from './restrictedProp';
 import sequenceOf from './sequenceOf';
@@ -58,6 +59,7 @@ module.exports = {
   object,
   or,
   range,
+  ref,
   requiredBy,
   restrictedProp,
   sequenceOf,

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -27,6 +27,7 @@ module.exports = {
   object: noopThunk,
   or: noopThunk,
   range: noopThunk,
+  ref: noopThunk,
   requiredBy: noopThunk,
   restrictedProp: noopThunk,
   sequenceOf: noopThunk,

--- a/src/ref.js
+++ b/src/ref.js
@@ -1,0 +1,34 @@
+import isPlainObject from './helpers/isPlainObject';
+import wrapValidator from './helpers/wrapValidator';
+
+function isNewRef(prop) {
+  if (!isPlainObject(prop)) {
+    return false;
+  }
+  const ownProperties = Object.keys(prop);
+  return ownProperties.length === 1 && ownProperties[0] === 'current';
+}
+
+function requiredRef(props, propName, componentName) {
+  const propValue = props[propName];
+
+  if (typeof propValue === 'function' || isNewRef(propValue)) {
+    return null;
+  }
+
+  return new TypeError(`${propName} in ${componentName} must be a ref`);
+}
+
+function ref(props, propName, componentName, ...rest) {
+  const propValue = props[propName];
+
+  if (propValue == null) {
+    return null;
+  }
+
+  return requiredRef(props, propName, componentName, ...rest);
+}
+
+ref.isRequired = requiredRef;
+
+export default () => wrapValidator(ref, 'ref');

--- a/test/ref.jsx
+++ b/test/ref.jsx
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import React from 'react';
+
+import { ref } from '..';
+
+import callValidator from './_callValidator';
+
+describe('ref', () => {
+  it('is a function', () => {
+    expect(typeof ref).to.equal('function');
+  });
+
+  function assertPasses(validator, element, propName) {
+    expect(callValidator(validator, element, propName, '"ref" test')).to.equal(null);
+  }
+
+  function assertFails(validator, element, propName) {
+    expect(callValidator(validator, element, propName, '"ref" test')).to.be.instanceOf(Error);
+  }
+
+  describe('not required', () => {
+    const validator = ref();
+
+    it('passes on null or undefined', () => {
+      assertPasses(validator, <div someRef={undefined} />, 'someRef');
+      assertPasses(validator, <div someRef={null} />, 'someRef');
+    });
+
+    it('passes when not present', () => {
+      assertPasses(validator, <div />, 'someRef');
+    });
+
+    it('passes with legacy refs', () => {
+      assertPasses(validator, <div someRef={() => {}} />, 'someRef');
+    });
+
+    it('passes with ref objects', () => {
+      assertPasses(validator, <div someRef={React.createRef()} />, 'someRef');
+    });
+
+    it('fails with non-refs', () => {
+      assertFails(validator, <div someRef={666} />, 'someRef');
+    });
+  });
+
+  describe('required', () => {
+    const validator = ref().isRequired;
+
+    it('fails on null or undefined', () => {
+      assertFails(validator, <div someRef={undefined} />, 'someRef');
+      assertFails(validator, <div someRef={null} />, 'someRef');
+    });
+
+    it('fails when not present', () => {
+      assertFails(validator, <div />, 'someRef');
+    });
+
+    it('passes with legacy refs', () => {
+      assertPasses(validator, <div someRef={() => {}} />, 'someRef');
+    });
+
+    it('passes with ref objects', () => {
+      assertPasses(validator, <div someRef={React.createRef()} />, 'someRef');
+    });
+
+    it('fails with non-refs', () => {
+      assertFails(validator, <div someRef={666} />, 'someRef');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a prop type for refs. Both the older callback and the newer `createRef` styles are supported.