### PR TITLE
Update ref prop type

### DIFF
--- a/src/ref.js
+++ b/src/ref.js
@@ -1,3 +1,4 @@
+import { Component, PureComponent } from 'react';
 import isPlainObject from './helpers/isPlainObject';
 import wrapValidator from './helpers/wrapValidator';
 
@@ -9,10 +10,17 @@ function isNewRef(prop) {
   return ownProperties.length === 1 && ownProperties[0] === 'current';
 }
 
+function isCallbackRef(prop) {
+  return typeof prop === 'function'
+    && !Object.prototype.isPrototypeOf.call(Component, prop)
+    && (!PureComponent || !Object.prototype.isPrototypeOf.call(PureComponent, prop))
+    && prop.length === 1;
+}
+
 function requiredRef(props, propName, componentName) {
   const propValue = props[propName];
 
-  if (typeof propValue === 'function' || isNewRef(propValue)) {
+  if (isCallbackRef(propValue) || isNewRef(propValue)) {
     return null;
   }
 

--- a/test/ref.jsx
+++ b/test/ref.jsx
@@ -31,14 +31,32 @@ describe('ref', () => {
     });
 
     it('passes with legacy refs', () => {
-      assertPasses(validator, <div someRef={() => {}} />, 'someRef');
+      assertPasses(validator, <div someRef={(node) => {}} />, 'someRef'); // eslint-disable-line no-unused-vars
     });
 
     it('passes with ref objects', () => {
       assertPasses(validator, <div someRef={React.createRef()} />, 'someRef');
     });
 
-    it('fails with non-refs', () => {
+    it('fails with React components', () => {
+      class A extends React.Component {
+        constructor(props) {} // eslint-disable-line
+      }
+      assertFails(validator, <div someRef={A} />, 'someRef');
+    });
+
+    it('fails with React pure components', () => {
+      class B extends React.PureComponent {
+        constructor(props) {} // eslint-disable-line
+      }
+      assertFails(validator, <div someRef={B} />, 'someRef');
+    });
+
+    it('fails with non-ref functions', () => {
+      assertFails(validator, <div someRef={() => {}} />, 'someRef');
+    });
+
+    it('fails with other non-refs', () => {
       assertFails(validator, <div someRef={666} />, 'someRef');
     });
   });
@@ -56,14 +74,32 @@ describe('ref', () => {
     });
 
     it('passes with legacy refs', () => {
-      assertPasses(validator, <div someRef={() => {}} />, 'someRef');
+      assertPasses(validator, <div someRef={(node) => {}} />, 'someRef'); // eslint-disable-line no-unused-vars
     });
 
     it('passes with ref objects', () => {
       assertPasses(validator, <div someRef={React.createRef()} />, 'someRef');
     });
 
-    it('fails with non-refs', () => {
+    it('fails with React components', () => {
+      class A extends React.Component {
+        constructor(props) {} // eslint-disable-line
+      }
+      assertFails(validator, <div someRef={A} />, 'someRef');
+    });
+
+    it('fails with React pure components', () => {
+      class B extends React.PureComponent {
+        constructor(props) {} // eslint-disable-line
+      }
+      assertFails(validator, <div someRef={B} />, 'someRef');
+    });
+
+    it('fails with non-ref functions', () => {
+      assertFails(validator, <div someRef={() => {}} />, 'someRef');
+    });
+
+    it('fails with other non-refs', () => {
       assertFails(validator, <div someRef={666} />, 'someRef');
     });
   });


### PR DESCRIPTION
This PR updates `ref` to:
- Ensure that callback refs are not descendants of React.Component (should take care of PureComponent, as well, since those also extend Component).
- Ensure that callback refs have a single argument