### PR TITLE
Remove arity check from ref prop type

### DIFF
--- a/src/ref.js
+++ b/src/ref.js
@@ -2,6 +2,8 @@ import { Component, PureComponent } from 'react';
 import isPlainObject from './helpers/isPlainObject';
 import wrapValidator from './helpers/wrapValidator';
 
+const { isPrototypeOf } = Object.prototype;
+
 function isNewRef(prop) {
   if (!isPlainObject(prop)) {
     return false;
@@ -12,9 +14,8 @@ function isNewRef(prop) {
 
 function isCallbackRef(prop) {
   return typeof prop === 'function'
-    && !Object.prototype.isPrototypeOf.call(Component, prop)
-    && (!PureComponent || !Object.prototype.isPrototypeOf.call(PureComponent, prop))
-    && prop.length === 1;
+    && !isPrototypeOf.call(Component, prop)
+    && (!PureComponent || !isPrototypeOf.call(PureComponent, prop));
 }
 
 function requiredRef(props, propName, componentName) {

--- a/test/ref.jsx
+++ b/test/ref.jsx
@@ -30,8 +30,8 @@ describe('ref', () => {
       assertPasses(validator, <div />, 'someRef');
     });
 
-    it('passes with legacy refs', () => {
-      assertPasses(validator, <div someRef={(node) => {}} />, 'someRef'); // eslint-disable-line no-unused-vars
+    it('passes with callback refs', () => {
+      assertPasses(validator, <div someRef={() => {}} />, 'someRef');
     });
 
     it('passes with ref objects', () => {
@@ -50,10 +50,6 @@ describe('ref', () => {
         constructor(props) {} // eslint-disable-line
       }
       assertFails(validator, <div someRef={B} />, 'someRef');
-    });
-
-    it('fails with non-ref functions', () => {
-      assertFails(validator, <div someRef={() => {}} />, 'someRef');
     });
 
     it('fails with other non-refs', () => {
@@ -73,8 +69,8 @@ describe('ref', () => {
       assertFails(validator, <div />, 'someRef');
     });
 
-    it('passes with legacy refs', () => {
-      assertPasses(validator, <div someRef={(node) => {}} />, 'someRef'); // eslint-disable-line no-unused-vars
+    it('passes with callback refs', () => {
+      assertPasses(validator, <div someRef={() => {}} />, 'someRef');
     });
 
     it('passes with ref objects', () => {
@@ -93,10 +89,6 @@ describe('ref', () => {
         constructor(props) {} // eslint-disable-line
       }
       assertFails(validator, <div someRef={B} />, 'someRef');
-    });
-
-    it('fails with non-ref functions', () => {
-      assertFails(validator, <div someRef={() => {}} />, 'someRef');
     });
 
     it('fails with other non-refs', () => {


### PR DESCRIPTION
In #54 we added a ref prop type, and in #55 added an arity check for callback refs. Unfortunately, that breaks a common pattern of having an empty function as a default value. For example:

```jsx
function SomeButton({ buttonRef }) {
  return <button buttonRef={buttonRef} />;
}

SomeButton.defaultProps = {
  buttonRef() {}
};
```

We could leave the arity check and change default values to `undefined`, instead. However, that's an unknown amount of work, and I think we're better off removing the arity check and accepting functions with any number of arguments.

@ljharb , what do you think?