### PR TITLE
[getComponentName] Add logic to handle React.memo

### DIFF
--- a/src/helpers/getComponentName.js
+++ b/src/helpers/getComponentName.js
@@ -1,5 +1,5 @@
 import getFunctionName from 'function.prototype.name';
-import { isForwardRef, Element } from 'react-is';
+import { isForwardRef, Element, isMemo } from 'react-is';
 
 export default function getComponentName(Component) {
   if (typeof Component === 'string') {
@@ -10,6 +10,9 @@ export default function getComponentName(Component) {
   }
   if (isForwardRef({ type: Component, $$typeof: Element })) {
     return Component.displayName;
+  }
+  if (isMemo(Component)) {
+    return getComponentName(Component.type);
   }
   return null;
 }

--- a/test/helpers/getComponentName.js
+++ b/test/helpers/getComponentName.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { expect } from 'chai';
 
 import getComponentName from '../../build/helpers/getComponentName';
@@ -14,6 +15,20 @@ describe('getComponentName', () => {
 
     Foo.displayName = 'Bar';
     expect(getComponentName(Foo)).to.equal(Foo.displayName);
+  });
+
+  it('given a memo, returns the name or displayName', () => {
+    function Foo() {}
+    const FooMemo = React.memo(Foo);
+    expect(getComponentName(FooMemo)).to.equal('Foo');
+
+    Foo.displayName = 'Bar';
+    const NamedFooMemo = React.memo(Foo);
+    expect(getComponentName(NamedFooMemo)).to.equal('Bar');
+
+    const AnonymousFoo = () => {};
+    const AnonymousFooMemo = React.memo(AnonymousFoo);
+    expect(getComponentName(AnonymousFooMemo)).to.equal('AnonymousFoo');
   });
 
   it('given anything else, returns null', () => {


### PR DESCRIPTION
### Summary

Add logic to handle `React.memo` names. This is how the react lib does it: 

https://github.com/facebook/react/blob/master/packages/shared/getComponentName.js#L82-L83

### Reviewers

@ljharb WDYT?