### PR TITLE
Improving published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.15.0",
   "description": "Custom React PropType validators that we use at Airbnb.",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "build/*"
+  ],
   "dependencies": {
     "array.prototype.find": "^2.1.0",
     "function.prototype.name": "^1.1.1",


### PR DESCRIPTION
At the moment prop-types is published with build, src and test directories along with a load of other files in the base directory. I don't believe these are needed and just slow down npm/yarn fetching the package.